### PR TITLE
Ultris5 UI

### DIFF
--- a/UI/image_tool.ui
+++ b/UI/image_tool.ui
@@ -3,12 +3,12 @@
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="adj_blue_init">
-    <property name="upper">163</property>
+    <property name="upper">51</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adj_green_init">
-    <property name="upper">163</property>
+    <property name="upper">51</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
@@ -25,7 +25,7 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adj_red_init">
-    <property name="upper">163</property>
+    <property name="upper">51</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>

--- a/examples/image_tool.cpp
+++ b/examples/image_tool.cpp
@@ -120,6 +120,8 @@ int main (int argc, char *argv[])
   gtk_spin_buttons=&temp_var4;
   (*gtk_spin_buttons).HyperFunctions1 = &HyperFunctions1;
 
+  int hello = 100;
+
   button = gtk_builder_get_object (builder, "spin_red");
   (*gtk_spin_buttons).button1 = button;
   g_signal_connect (button, "value-changed", G_CALLBACK (set_false_img_r), gtk_hyper_image);

--- a/examples/image_tool.cpp
+++ b/examples/image_tool.cpp
@@ -70,17 +70,20 @@ int main (int argc, char *argv[])
   GObject* spin_red_button = gtk_builder_get_object (builder, "spin_red");
   (*gtk_spin_buttons).button1 = spin_red_button;
   g_signal_connect (spin_red_button, "value-changed", G_CALLBACK (set_false_img_r), gtk_hyper_image);
-  //gtk_spin_button_set_range(spin_red_button, 0, HyperFunctions1.mlt1.size());
+  GtkSpinButton *spin_button = GTK_SPIN_BUTTON(spin_red_button);
+  gtk_spin_button_set_range(spin_button, 0, HyperFunctions1.mlt1.size()-1);
  
   GObject* spin_green_button = gtk_builder_get_object (builder, "spin_green");
   (*gtk_spin_buttons).button2 = spin_green_button;
   g_signal_connect (spin_green_button, "value-changed", G_CALLBACK (set_false_img_g), gtk_hyper_image);
-  //gtk_spin_button_set_range(spin_green_button, 0, HyperFunctions1.mlt1.size());
+  spin_button = GTK_SPIN_BUTTON(spin_green_button);
+  gtk_spin_button_set_range(spin_button, 0, HyperFunctions1.mlt1.size()-1);
   
   GObject* spin_blue_button = gtk_builder_get_object (builder, "spin_blue");
   (*gtk_spin_buttons).button3 = spin_blue_button;
   g_signal_connect (spin_blue_button, "value-changed", G_CALLBACK (set_false_img_b), gtk_hyper_image);
-  //gtk_spin_button_set_range(spin_blue_button, 0, HyperFunctions1.mlt1.size());
+  spin_button = GTK_SPIN_BUTTON(spin_blue_button);
+  gtk_spin_button_set_range(spin_button, 0, HyperFunctions1.mlt1.size()-1);
 
   /* Connect signal handlers to the constructed widgets. */
   window = gtk_builder_get_object (builder, "window");

--- a/examples/image_tool.cpp
+++ b/examples/image_tool.cpp
@@ -52,18 +52,6 @@ int main (int argc, char *argv[])
     }
 
 
-  /* Connect signal handlers to the constructed widgets. */
-  window = gtk_builder_get_object (builder, "window");
-  g_signal_connect (window, "destroy", G_CALLBACK (gtk_main_quit), NULL);
-
-  button = gtk_builder_get_object (builder, "choose_file");
-  g_signal_connect (button, "file-set", G_CALLBACK (choose_image_file), &HyperFunctions1); 
-
-  button = gtk_builder_get_object(builder, "choose_database");
-  g_signal_connect (button, "file-set", G_CALLBACK (choose_database), &HyperFunctions1); 
-
-  button = gtk_builder_get_object (builder, "spectrum_box");
-
   img_struct *gtk_hyper_image, temp_var1;
   gtk_hyper_image=&temp_var1;
   GObject *image;
@@ -74,6 +62,38 @@ int main (int argc, char *argv[])
 
   entry_struct *gtk_hyper_entry, temp_var3;
   gtk_hyper_entry=&temp_var3;
+
+  spin_struct *gtk_spin_buttons, temp_var4;
+  gtk_spin_buttons=&temp_var4;
+  (*gtk_spin_buttons).HyperFunctions1 = &HyperFunctions1;
+
+  GObject* spin_red_button = gtk_builder_get_object (builder, "spin_red");
+  (*gtk_spin_buttons).button1 = spin_red_button;
+  g_signal_connect (spin_red_button, "value-changed", G_CALLBACK (set_false_img_r), gtk_hyper_image);
+  //gtk_spin_button_set_range(spin_red_button, 0, HyperFunctions1.mlt1.size());
+ 
+  GObject* spin_green_button = gtk_builder_get_object (builder, "spin_green");
+  (*gtk_spin_buttons).button2 = spin_green_button;
+  g_signal_connect (spin_green_button, "value-changed", G_CALLBACK (set_false_img_g), gtk_hyper_image);
+  //gtk_spin_button_set_range(spin_green_button, 0, HyperFunctions1.mlt1.size());
+  
+  GObject* spin_blue_button = gtk_builder_get_object (builder, "spin_blue");
+  (*gtk_spin_buttons).button3 = spin_blue_button;
+  g_signal_connect (spin_blue_button, "value-changed", G_CALLBACK (set_false_img_b), gtk_hyper_image);
+  //gtk_spin_button_set_range(spin_blue_button, 0, HyperFunctions1.mlt1.size());
+
+  /* Connect signal handlers to the constructed widgets. */
+  window = gtk_builder_get_object (builder, "window");
+  g_signal_connect (window, "destroy", G_CALLBACK (gtk_main_quit), NULL);
+
+  button = gtk_builder_get_object (builder, "choose_file");
+  g_signal_connect (button, "file-set", G_CALLBACK (choose_image_file), &HyperFunctions1); 
+  g_signal_connect (button, "file-set", G_CALLBACK (adjust_spin_ranges), gtk_spin_buttons); 
+
+  button = gtk_builder_get_object(builder, "choose_database");
+  g_signal_connect (button, "file-set", G_CALLBACK (choose_database), &HyperFunctions1); 
+
+  button = gtk_builder_get_object (builder, "spectrum_box");
   
   button = gtk_builder_get_object (builder, "database_name");
   (*gtk_hyper_entry).entry=button;
@@ -115,25 +135,6 @@ int main (int argc, char *argv[])
   
   button = gtk_builder_get_object (builder, "tiled_img");
   g_signal_connect (button, "clicked", G_CALLBACK (TileImage), gtk_hyper_image);
-  
-  spin_struct *gtk_spin_buttons, temp_var4;
-  gtk_spin_buttons=&temp_var4;
-  (*gtk_spin_buttons).HyperFunctions1 = &HyperFunctions1;
-
-  int hello = 100;
-
-  button = gtk_builder_get_object (builder, "spin_red");
-  (*gtk_spin_buttons).button1 = button;
-  g_signal_connect (button, "value-changed", G_CALLBACK (set_false_img_r), gtk_hyper_image);
- 
-  button = gtk_builder_get_object (builder, "spin_green");
-  (*gtk_spin_buttons).button2 = button;
-  g_signal_connect (button, "value-changed", G_CALLBACK (set_false_img_g), gtk_hyper_image);
-  
-  button = gtk_builder_get_object (builder, "spin_blue");
-  (*gtk_spin_buttons).button3 = button;
-  g_signal_connect (button, "value-changed", G_CALLBACK (set_false_img_b), gtk_hyper_image);  
-
 
   button = gtk_builder_get_object (builder, "spin_height");
   (*gtk_spin_buttons).button4 = button;

--- a/src/gtkfunctions.cpp
+++ b/src/gtkfunctions.cpp
@@ -325,9 +325,15 @@ static void set_false_img_standard_rgb(GtkWidget *widget,  gpointer data)
     void * data_new2=img_struct1->HyperFunctions1;
     HyperFunctions *HyperFunctions1=static_cast<HyperFunctions*>(data_new2);  
   
+    HyperFunctions1->false_img_r=31; //Hard-coded for the ultris5 camera
+    HyperFunctions1->false_img_g=13;
+    HyperFunctions1->false_img_b=2;
+
+    /*
     HyperFunctions1->false_img_r=163;
     HyperFunctions1->false_img_g=104;
     HyperFunctions1->false_img_b=65;
+    */
     HyperFunctions1->GenerateFalseImg();
  
     cv::Mat output=HyperFunctions1->false_img;

--- a/src/gtkfunctions.cpp
+++ b/src/gtkfunctions.cpp
@@ -36,6 +36,7 @@ static void choose_image_file(GtkFileChooser *widget,  gpointer data) {
 
     gchar* file_chosen;
     file_chosen = gtk_file_chooser_get_filename(widget);
+
     void * data_new=data;
     HyperFunctions *HyperFunctions1=static_cast<HyperFunctions*>(data_new);
     HyperFunctions1->LoadImageHyper1(file_chosen);
@@ -353,6 +354,18 @@ static void set_spin_buttons_reset(GtkWidget *widget,  gpointer data)
     gtk_spin_button_set_value((*spin_struct1).button1,0);
     gtk_spin_button_set_value((*spin_struct1).button2,0);
     gtk_spin_button_set_value((*spin_struct1).button3,0);
+}
+
+static void adjust_spin_ranges(GtkWidget *widget,  gpointer data) {
+    void * data_new=data;
+    spin_struct_gtk *spin_struct1=static_cast<spin_struct_gtk*>(data_new);
+    void * data_new2=spin_struct1->HyperFunctions1;
+    HyperFunctions *HyperFunctions1=static_cast<HyperFunctions*>(data_new2);
+
+    std::cout << HyperFunctions1->mlt1.size()-1 << std::endl;
+    gtk_spin_button_set_range((*spin_struct1).button1, 0, HyperFunctions1->mlt1.size());
+    gtk_spin_button_set_range((*spin_struct1).button2, 0, HyperFunctions1->mlt1.size());
+    gtk_spin_button_set_range((*spin_struct1).button3, 0, HyperFunctions1->mlt1.size());
 }
 
 static void set_spin_buttons_standard_rgb(GtkWidget *widget,  gpointer data) {


### PR DESCRIPTION
Changes imagetool so that the layer-changing spin buttons do not go beyond the number of layers in an image. Prevents access to layers that do not exist.